### PR TITLE
Fix dtool import in plugin.py after dtool move to ibeis

### DIFF
--- a/ibeis_flukematch/plugin.py
+++ b/ibeis_flukematch/plugin.py
@@ -35,7 +35,7 @@ CommandLine:
 from __future__ import absolute_import, division, print_function, unicode_literals
 import ibeis
 import utool as ut
-import dtool  # NOQA
+from ibeis import dtool  # NOQA
 import numpy as np
 import vtool as vt
 import cv2


### PR DESCRIPTION
dtool was a separate package but has been moved into ibeis.  So imports
need to change from `import dtool` to `from ibeis import dtool`.